### PR TITLE
Update language_de.ini, fix issue with displaying of °C with german language pack 

### DIFF
--- a/Copy to SD Card root directory to update/Language Packs/language_de.ini
+++ b/Copy to SD Card root directory to update/Language Packs/language_de.ini
@@ -1,5 +1,5 @@
 #### Language Code:DE
-## Language Version:20210522
+## Language Version:20210528
 ## Maximum byte per keyword is 250 Bytes.
 ## Escape characters are not supported except newline '\n'
 
@@ -130,7 +130,7 @@ label_invalid_value:Ungültige(r) Wert(e)!
 label_timeout_reached:Zeit überschritten!
 label_disconnect_info:Verbindung getrennt!
 label_shutting_down:Fahre herunter...
-label_wait_temp_shut_down:Warte bis Düsen-\ntemperatur unter\n%d℃ fällt.
+label_wait_temp_shut_down:Warte bis Düsen-\ntemperatur unter\n%d°C fällt.
 label_power_failed:Druck fortsetzen?
 label_process_running:Prozess läuft bereits!
 label_process_completed:Prozess fertiggestellt!
@@ -162,9 +162,9 @@ label_chamber:Kammer
 label_fan:Lüfter
 label_bltouch:BLTouch
 label_touchmi:TouchMi
-label_1_degree:1℃
-label_5_degree:5℃
-label_10_degree:10℃
+label_1_degree:1°C
+label_5_degree:5°C
+label_10_degree:10°C
 label_001_mm:0.01mm
 label_01_mm:0.1mm
 label_1_mm:1mm
@@ -285,7 +285,7 @@ label_pid_start_info_3:Berühren Sie den Bildschirm erst nach Fertigstellung (gr
 label_tune_extruder:Schritte
 label_tune_ext_extrude_100:100mm ext.
 label_tune_ext_temp:Düsentemperatur
-label_tune_ext_templow:Temparatur zu niedrig!\nMinimale Temparatur: %d℃
+label_tune_ext_templow:Temparatur zu niedrig!\nMinimale Temparatur: %d°C
 label_tune_ext_desiredval:Temparatur hat gewünschten Wert noch nicht erreicht!
 label_tune_ext_mark120mm:Filament 120 mm über Einlass markieren,\ndann '%s' drücken & nach Extrusion\nerneut messen.
 label_tune_ext_heatoff:Heizung abschalten?
@@ -311,8 +311,8 @@ label_filament_weight:Filament Gewicht: %1.2fg\n
 label_filament_cost:Filament Kosten: %1.2f\n
 label_no_filament_stats:Filament Daten nicht verfügbar.
 label_click_for_more:Klick für Statistik
-label_ext_templow:Temperatur der Düse liegt\nunter dem Minimum (%d℃).
-label_heat_hotend:Heize Düse auf %d℃?
+label_ext_templow:Temperatur der Düse liegt\nunter dem Minimum (%d°C).
+label_heat_hotend:Heize Düse auf %d°C?
 label_z_align:Z ausr.
 label_macros:Macros
 label_mesh_valid:Mesh Validation


### PR DESCRIPTION
### Requirements

Character "°" is not displayed correctly in german language on TFT70 with Firmware Vx.x.27. Character should be displayed correctly e.g. in °C.

### Description

Incorrect encoding of "°" prevented symbol from being displayed correctly.
This pull request encodes the symbol correctly, in order to be displayed correctly 
on the TFT70 display
as well as in editors and IDEs (fileencoding=utf-8, ff=unix), some editors like vim must made aware of UTF-8 encoding (:se enc=UTf-8) in order to not destroy the file. 


### Benefits

Temperatures get displayed with correct unit smbol "°C" on the TFT70 in German language.
 
### Related Issues

This encoding problem may also apply to other language_xx.ini files of other languages or displays
